### PR TITLE
fix(docker): moved auth view of gradio to prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -105,6 +105,10 @@ services:
       - 7860
     environment:
       - API_URL=http://backend:5050/api/v1
+      - SUPERADMIN_LOGIN=${SUPERADMIN_LOGIN}
+      - SUPERADMIN_PWD=${SUPERADMIN_PWD}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+      - POSTHOG_KEY=${POSTHOG_KEY}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.grafana.rule=Host(`${GRADIO_HOST}`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       - 7860:7860
     environment:
       - API_URL=http://backend:5050/api/v1
+      - SUPERADMIN_LOGIN=${SUPERADMIN_LOGIN}
+      - SUPERADMIN_PWD=${SUPERADMIN_PWD}
     volumes:
       - ./demo/:/app/
     command: python main.py --server-name 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,6 @@ services:
       - 7860:7860
     environment:
       - API_URL=http://backend:5050/api/v1
-      - SUPERADMIN_LOGIN=${SUPERADMIN_LOGIN}
-      - SUPERADMIN_PWD=${SUPERADMIN_PWD}
     volumes:
       - ./demo/:/app/
     command: python main.py --server-name 0.0.0.0


### PR DESCRIPTION
This PR moves the auth view to the prod docker orchestration and remove it from dev.