### PR TITLE
feat(router): make the router immune to missing trailing slashes

### DIFF
--- a/scripts/test_e2e.py
+++ b/scripts/test_e2e.py
@@ -68,6 +68,8 @@ def main(args):
     # Get & Fetch access
     api_request("get", f"{args.endpoint}/users/{user_id}/", superuser_auth)
     api_request("get", f"{args.endpoint}/users/", superuser_auth)
+    # Check that redirect is working
+    api_request("get", f"{args.endpoint}/users", superuser_auth)
     # Modify access
     new_pwd = "my_new_pwd"  # noqa S105
     api_request("patch", f"{args.endpoint}/users/{user_id}/", superuser_auth, {"password": new_pwd})

--- a/src/app/api/api_v1/router.py
+++ b/src/app/api/api_v1/router.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter
 
 from app.api.api_v1.endpoints import code, guidelines, login, repos, users
 
-api_router = APIRouter()
+api_router = APIRouter(redirect_slashes=True)
 api_router.include_router(login.router, prefix="/login", tags=["login"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(repos.router, prefix="/repos", tags=["repos"])


### PR DESCRIPTION
This PR ensures requests are redirected to the endpoint with trailing slashes to avoid unnecessary 404 response.