### PR TITLE
The utcnow() method will be deprecated soon. Replaced it with recommened method.

### DIFF
--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Any, Dict, Optional
 
 import jwt
@@ -19,7 +19,7 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 def create_access_token(content: Dict[str, Any], expires_minutes: Optional[int] = None) -> str:
     """Encode content dict using security algorithm, setting expiration."""
     expire_delta = timedelta(minutes=expires_minutes or settings.JWT_EXPIRE_MINUTES)
-    expire = datetime.utcnow() + expire_delta
+    expire = datetime.now(UTC) + expire_delta
     return jwt.encode({**content, "exp": expire}, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
 
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -3,7 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
-from datetime import datetime
+from datetime import datetime, UTC
 from enum import Enum
 from typing import Union
 
@@ -36,7 +36,7 @@ class User(SQLModel, table=True):
     provider_user_id: Union[int, None] = Field(None, gt=0)
     login: Union[str, None] = Field(None, min_length=2, max_length=50)
     hashed_password: Union[str, None] = Field(None, min_length=5, max_length=70)
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    created_at: datetime = Field(default_factory=datetime.now(UTC), nullable=False)
 
 
 class Repository(SQLModel, table=True):

--- a/src/tests/test_security.py
+++ b/src/tests/test_security.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import jwt
 import pytest
@@ -34,7 +34,7 @@ def test_verify_password():
 )
 def test_create_access_token(content, expires_minutes, expected_delta):
     payload = create_access_token(content, expires_minutes)
-    after = datetime.utcnow()
+    after = datetime.now(UTC)
     assert isinstance(payload, str)
     decoded_data = jwt.decode(payload, settings.JWT_SECRET, algorithms=[settings.JWT_ALGORITHM])
     # Verify data integrity


### PR DESCRIPTION
Hey I noticed that at some places the utcnow() method has been use. 

Since the function will be deprecated soon I have replaced this with the recommended one. 

```python
from datetime import datetime, UTC
print(datetime.now(UTC))
```

