### PR TITLE
build(deps): bump jinja2 from 3.1.3 to 3.1.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1076,13 +1076,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.3"
+version = "3.1.4"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
-    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
+    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
+    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
 ]
 
 [package.dependencies]
@@ -3050,4 +3050,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b20d014a5ca94e0cd1ea76f9a099f85628c98b5187adf40b9af3a226498a4b7f"
+content-hash = "097c2abf5499bd974f0b63d9f8597704125bc6a30caa266e60636d2d6caee07b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3050,4 +3050,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "097c2abf5499bd974f0b63d9f8597704125bc6a30caa266e60636d2d6caee07b"
+content-hash = "b20d014a5ca94e0cd1ea76f9a099f85628c98b5187adf40b9af3a226498a4b7f"


### PR DESCRIPTION
This PR addresses [Dependabot security alert](https://github.com/quack-ai/companion/security/dependabot/17)