### PR TITLE
build(docker): bump ollama to 0.1.47

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       retries: 3
 
   ollama:
-    image: ollama/ollama:0.1.38
+    image: ollama/ollama:0.1.47
     expose:
       - 11434
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
     restart: always
 
   ollama:
-    image: ollama/ollama:0.1.38
+    image: ollama/ollama:0.1.47
     expose:
       - 11434
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   ollama:
-    image: ollama/ollama:0.1.38
+    image: ollama/ollama:0.1.47
     expose:
       - 11434
     volumes:


### PR DESCRIPTION
This PR bumps ollama from 0.1.38 to 0.1.47 in all docker orchestrations