### PR TITLE
build(docker): bump ollama from 0.1.47 to 0.2.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,15 @@ updates:
       - dependency-name: "ruff"
       - dependency-name: "mypy"
       - dependency-name: "pre-commit"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    reviewers:
+      - "frgfm"
+    assignees:
+      - "frgfm"
+    allow:
+      - dependency-name: "ollama/ollama"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       retries: 3
 
   ollama:
-    image: ollama/ollama:0.1.47
+    image: ollama/ollama:0.2.1
     expose:
       - 11434
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
     restart: always
 
   ollama:
-    image: ollama/ollama:0.1.47
+    image: ollama/ollama:0.2.1
     expose:
       - 11434
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   ollama:
-    image: ollama/ollama:0.1.47
+    image: ollama/ollama:0.2.1
     expose:
       - 11434
     volumes:


### PR DESCRIPTION
This PR bumps ollama to the latest version and adds a dependabot job to keep the docker image up-to-date